### PR TITLE
Improved existing mixin for planting plants on blocks

### DIFF
--- a/src/main/java/com/tylervp/mixin/PlantBlockMixin.java
+++ b/src/main/java/com/tylervp/mixin/PlantBlockMixin.java
@@ -18,6 +18,8 @@ public class PlantBlockMixin {
 
     @Inject(method = "canPlantOnTop(Lnet/minecraft/block/BlockState;Lnet/minecraft/world/BlockView;Lnet/minecraft/util/math/BlockPos;)Z", at = @At("HEAD"), cancellable = true)
     protected void canPlantOnTop(BlockState floor, BlockView world, BlockPos pos, CallbackInfoReturnable<Boolean> ci) {
-        ci.setReturnValue(floor.isOf(Blocks.SAND) || floor.isOf(Blocks.GRASS_BLOCK) || floor.isOf(Blocks.DIRT) || floor.isOf(Blocks.COARSE_DIRT) || floor.isOf(Blocks.PODZOL) || floor.isOf(Blocks.FARMLAND) || floor.isOf(MBMBlocks.DEAD_GRASS_BLOCK));
+        if (floor.isOf(MBMBlocks.DEAD_GRASS_BLOCK)) {
+            ci.setReturnValue(true);
+        }
     }
 }


### PR DESCRIPTION
Hi again.

I believe this pull request improves upon PlantBlockMixin by achieving what I believe was the purpose of that mixin all along and fixing some issues caused by using a predefined list of blocks instead of leaving the rest to Minecraft.

This change in code was a result of complaints from players of my server about inability to plant azalia trees on moss blocks. The old code didn't specify moss blocks as plantable blocks therefore broke vanilla mechanics. I believe that the mod should modify behavior only for it's own blocks in this case and do not break compatibility with other mods/Minecraft features therefore I changed the code to always return true for DEAD_GRASS_BLOCK and in other cases let the canPlantOnTop function run.
I've tested my change on my own world and indeed moss became a plantable block, dead grass from mbm is still plantable and other blocks which are not supposed to be plantable are not. 

Please do note however that similar issue affects dead bush mixin and that one I'm not entirely sure how to fix since that one overwrites the default function completely.